### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/probaku1234/cli_prompt_rs/compare/v0.1.0...v0.1.1) - 2023-10-09
+
+### Other
+- update README file
+- update README.md file
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
 ## [0.1.0](https://github.com/probaku1234/cli_prompt_rs/releases/tag/v0.1.0) - 2023-10-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli_prompts_rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Easily build beautiful command-line apps"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `cli_prompts_rs`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).